### PR TITLE
Delete README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-README.org


### PR DESCRIPTION
Github will display anything with README in it , as   long as there is no README.md. Now it only displays README.org.